### PR TITLE
feat: implement login filter

### DIFF
--- a/src/main/java/com/example/board/config/FilterConfig.java
+++ b/src/main/java/com/example/board/config/FilterConfig.java
@@ -1,0 +1,19 @@
+package com.example.board.config;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.example.board.filter.LoginFilter;
+
+import jakarta.servlet.Filter;
+
+@Configuration
+public class FilterConfig {
+    @Bean
+    public FilterRegistrationBean<Filter> filterBean() {
+        FilterRegistrationBean<Filter> bean = new FilterRegistrationBean<>(new LoginFilter());
+        bean.addUrlPatterns("/signin", "/board/write");
+        return bean;
+    }
+}

--- a/src/main/java/com/example/board/filter/LoginFilter.java
+++ b/src/main/java/com/example/board/filter/LoginFilter.java
@@ -1,0 +1,45 @@
+package com.example.board.filter;
+
+import java.io.IOException;
+
+import com.example.board.entity.User;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class LoginFilter implements Filter{
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        HttpServletRequest req = (HttpServletRequest) request;
+        HttpServletResponse res = (HttpServletResponse) response;
+
+        String url = req.getRequestURI();
+        System.out.println(url);
+
+        HttpSession session = req.getSession();
+        User user = (User) session.getAttribute("user_info");
+        if(user == null && url.equals("/board/write")) {
+            log.info("/board/write 필터 수행!!!!!!!!!!!");
+            res.sendRedirect("/signin");
+            return;
+        }
+
+        if(user != null && url.equals("/signin")) {
+            log.info("/signin 필터 수행!!!!!!!!!!!");
+            res.sendRedirect("/board/list");
+            return;
+        }
+        chain.doFilter(request, response);
+    }
+    
+}


### PR DESCRIPTION
LoginFilter.java 작성
- 로그인하지 않은 사용자는 글쓰기 접근 시 /signin으로 리다이렉트
- 로그인 상태에서 /signin 접근 시 /board/list로 이동

FilterConfig.java 작성
- FilterRegistrationBean을 사용하여 LoginFilter bean 등록
- /signin, /board/write 요청 시, Filter가 적용된다.

로그인 상태를 체크하여 비로그인 사용자가 글쓰기 페이지에 접근하지 못하도록 제한하고, 
로그인된 사용자가 로그인 페이지에 접근하면 자동으로 게시글 목록 페이지로 리다이렉트되도록 구현.