### PR TITLE
 refactor(file): move FileAtch lookup logic from view to download controller

### DIFF
--- a/src/main/java/com/example/board/controller/DownloadController.java
+++ b/src/main/java/com/example/board/controller/DownloadController.java
@@ -1,0 +1,50 @@
+package com.example.board.controller;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.file.Files;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import com.example.board.entity.Board;
+import com.example.board.entity.FileAtch;
+import com.example.board.repository.FileAtchRepository;
+
+@Controller
+public class DownloadController {
+
+    @Autowired
+    FileAtchRepository fileAtchRepository;
+
+    @GetMapping("/download")
+    public ResponseEntity<Resource> download(@RequestParam Long boardId)
+            throws FileNotFoundException, UnsupportedEncodingException {
+        Board board = new Board();
+        board.setId(boardId);
+        FileAtch fileAtch = fileAtchRepository.findByBoard(board);
+        String cName = fileAtch.getCName();
+        File file = new File("c:/upload/board/" + cName);
+
+        InputStreamResource resource = new InputStreamResource(new FileInputStream(file));
+        return ResponseEntity.ok()
+                .header("content-disposition",
+                        "attachment; filename=\"" +
+                                URLEncoder.encode(file.getName(), "utf-8") + "\"")
+                .contentLength(file.length())
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .body(resource);
+    }
+}

--- a/src/main/java/com/example/board/entity/FileAtch.java
+++ b/src/main/java/com/example/board/entity/FileAtch.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import lombok.Data;
 

--- a/src/main/resources/templates/board/view.html
+++ b/src/main/resources/templates/board/view.html
@@ -22,7 +22,7 @@
         <h5 class="card-title" th:text="${board.title}"></h5>
         <h6 class="card-subtitle mb-2 text-muted" th:text="${board.user.id}"></h6>
         <p class="card-text" th:text="${board.content}"></p>
-        <img th:if="${fileAtch != null}" th:src="@{/image/{file}(file=${fileAtch.cName})}" alt="첨부 이미지" width="200">
+        <img th:src="@{/download(boardId=${board.id})}" alt="첨부 이미지" width="250">
       </div>
     </div>
   </div>


### PR DESCRIPTION

- 뷰 컨트롤러에서 파일 객체를 미리 조회해 전달하는 방식은 보안상 위험
- 대신 다운로드 컨트롤러에서 boardId로 FileAtch를 직접 조회하도록 변경
- 프론트는 file 객체 대신 boardId만 전달하도록 수정